### PR TITLE
Fix bulk uploader

### DIFF
--- a/scripts/pinata-upload.ts
+++ b/scripts/pinata-upload.ts
@@ -46,6 +46,7 @@ export async function pinataUpload() {
 
   // Upload each image to IPFS and store hash in array
   const uploadedImages: { IpfsHash: any }[] = [];
+  let index = 1;
   for (let image of images) {
     // Create readable stream
     const readableStreamForFile = fs.createReadStream(
@@ -54,8 +55,9 @@ export async function pinataUpload() {
 
     // Upload to IPFS
     await pinata.pinFileToIPFS(readableStreamForFile).then((i) => {
-      console.log(`Uploaded Image: ${image} / ${images.length}`);
+      console.log(`Uploaded Image: ${image}  ${index}/${images.length}`);
       console.log(i);
+      index++;
       uploadedImages.push(i);
     });
   }


### PR DESCRIPTION
I was running into rate-limiting issues with Pinata because of these lines here:
```ts
 const imagePromises = images.map(async (image) => {
...
    const result = await pinata.pinFromFS(tmpFolder);
```

In JS `map` doesn't actually wait for the request so this was flooding Pinata and causing their rate-limiting to trigger. I moved the async function inside a for loop, which should run the requests sequentially and added a bit more logging so its clear to the user as to the progress. This is helpful for me or other who may have a huge collection that takes awhile to upload
