### PR TITLE
Batch Unpin from Pinata

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "batch-mint": "cosmwasm-cli --init scripts/mint-batch.ts --code 'process.exit(0)'",
     "whitelist": "cosmwasm-cli --init scripts/whitelist.ts --code 'process.exit(0)'",
     "load": "cosmwasm-cli --init scripts/load.ts",
-    "pinata-upload": "ts-node scripts/pinata-upload.ts"
+    "pinata-upload": "ts-node scripts/pinata-upload.ts",
+    "pinata-clean": "ts-node scripts/pinata-clean.ts"
   }
 }

--- a/scripts/pinata-clean.ts
+++ b/scripts/pinata-clean.ts
@@ -1,0 +1,25 @@
+import pinataSDK from '@pinata/sdk';
+
+// Load config
+const config = require('../config');
+
+// Configure Pinata
+const apiKey = config.pinataApiKey;
+const secretKey = config.pinataSecretKey;
+const pinata = pinataSDK(apiKey, secretKey);
+
+export async function pinataClean() {
+  const allPins = await pinata.pinList({ status: 'pinned', pageLimit: 1000 });
+  let index = 1;
+  for (let pin of allPins.rows) {
+    // Upload to IPFS
+    console.log(pin);
+    await pinata.unpin(pin.ipfs_pin_hash);
+    console.log(
+      `Removed pin ${index}/${allPins.rows.length} : ${pin.ipfs_pin_hash}`
+    );
+    index++;
+  }
+}
+
+pinataClean();

--- a/scripts/pinata-upload.ts
+++ b/scripts/pinata-upload.ts
@@ -46,6 +46,7 @@ export async function pinataUpload() {
 
   // Upload each image to IPFS and store hash in array
   const uploadedImages: { IpfsHash: any }[] = [];
+  let index = 1;
   for (let image of images) {
     // Create readable stream
     const readableStreamForFile = fs.createReadStream(
@@ -54,8 +55,9 @@ export async function pinataUpload() {
 
     // Upload to IPFS
     await pinata.pinFileToIPFS(readableStreamForFile).then((i) => {
-      console.log(`Uploaded Image: ${image} / ${images.length}`);
+      console.log(`Uploaded Image: ${image}  ${index}/${images.length}`);
       console.log(i);
+      index++;
       uploadedImages.push(i);
     });
   }


### PR DESCRIPTION
I needed to be able to start from scratch and re-upload so I decided to script this to allow me to wipe my Pinata directory. It should clean up to 1000 files at a time. You can rerun as many times as you need.
```
yarn run pinata-clean
```