### PR TITLE
WIP: Fix NFT.storage uploader

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "minter": "cosmwasm-cli --init scripts/minter.ts --code 'process.exit(0)'",
     "mint": "cosmwasm-cli --init scripts/mint.ts --code 'process.exit(0)'",
     "nft-storage-upload": "ts-node scripts/nft-storage-upload.ts",
+    "nft-storage-clean": "ts-node scripts/nft-storage-clean.ts",
     "batch-mint": "cosmwasm-cli --init scripts/mint-batch.ts --code 'process.exit(0)'",
     "whitelist": "cosmwasm-cli --init scripts/whitelist.ts --code 'process.exit(0)'",
     "load": "cosmwasm-cli --init scripts/load.ts",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "minter": "cosmwasm-cli --init scripts/minter.ts --code 'process.exit(0)'",
     "mint": "cosmwasm-cli --init scripts/mint.ts --code 'process.exit(0)'",
     "nft-storage-upload": "ts-node scripts/nft-storage-upload.ts",
-    "nft-storage-clean": "ts-node scripts/nft-storage-clean.ts",
     "batch-mint": "cosmwasm-cli --init scripts/mint-batch.ts --code 'process.exit(0)'",
     "whitelist": "cosmwasm-cli --init scripts/whitelist.ts --code 'process.exit(0)'",
     "load": "cosmwasm-cli --init scripts/load.ts",

--- a/scripts/nft-storage-upload.ts
+++ b/scripts/nft-storage-upload.ts
@@ -43,57 +43,64 @@ export async function nftStorageUpload() {
   // Validation
   checkFiles(images, metadata);
 
-  // Upload each image to IPFS and store hash in array
-  const imagePromises = images.map(async (image) => {
+  const uploadedImages: any[] = [];
+  let uploadIndex = 1;
+  for (let image of images) {
     const imagePath = `${imagesBasePath}/${image}`;
     const readableFile = await fs.promises.readFile(imagePath);
     const type = mime.getType(imagePath);
 
     // Upload to IPFS
-    return await client.storeBlob(
-      new File([readableFile], path.basename(imagePath), { type } as any)
+    await client
+      .storeBlob(
+        new File([readableFile], path.basename(imagePath), { type } as any)
+      )
+      .then((i) => {
+        console.log(
+          `Uploaded Image: ${image}  ${uploadIndex}/${images.length}`
+        );
+        console.log(i);
+        uploadIndex++;
+        uploadedImages.push(i);
+      });
+  }
+
+  // Create temp upload folder for metadata
+  const tmpFolder = fs.mkdtempSync(path.join(os.tmpdir(), 'galaxy'));
+
+  // Update metadata with IPFS hashes
+  metadata.map(async (file, index: number) => {
+    // Read JSON file
+    let metadata = JSON.parse(
+      fs.readFileSync(`${metadataBasePath}/${file}`, 'utf8')
     );
+
+    // Set image to upload image IPFS hash
+    metadata.image = `ipfs://${uploadedImages[index]}`;
+
+    // Write updated metadata to tmp folder
+    // We add 1, because token IDs start at 1
+    fs.writeFileSync(`${tmpFolder}/${index + 1}`, JSON.stringify(metadata));
   });
 
-  // Wait for all images to be uploaded
-  await Promise.all(imagePromises).then(async (images) => {
-    // Create temp upload folder for metadata
-    const tmpFolder = fs.mkdtempSync(path.join(os.tmpdir(), 'galaxy'));
+  // Upload tmpFolder
+  const files = await getFilesFromPath(tmpFolder);
+  const result = await client.storeDirectory(files as any);
 
-    // Update metadata with IPFS hashes
-    metadata.map(async (file, index: number) => {
-      // Read JSON file
-      let metadata = JSON.parse(
-        fs.readFileSync(`${metadataBasePath}/${file}`, 'utf8')
-      );
+  // Project will have been uploaded into a randomly name folder
+  const projectPath = tmpFolder.split('/').pop();
 
-      // Set image to upload image IPFS hash
-      metadata.image = `ipfs://${images[index]}`;
+  // Set base token uri
+  const baseTokenUri = `ipfs://${result}/${projectPath}`;
 
-      // Write updated metadata to tmp folder
-      // We add 1, because token IDs start at 1
-      fs.writeFileSync(`${tmpFolder}/${index + 1}`, JSON.stringify(metadata));
-    });
+  console.log('Set these fields in your config.js file: ');
+  console.log('baseTokenUri: ', baseTokenUri);
+  console.log('contractUri: ', contractUri);
 
-    // Upload tmpFolder
-    const files = await getFilesFromPath(tmpFolder);
-    const result = await client.storeDirectory(files as any);
-
-    // Project will have been uploaded into a randomly name folder
-    const projectPath = tmpFolder.split('/').pop();
-
-    // Set base token uri
-    const baseTokenUri = `ipfs://${result}/${projectPath}`;
-
-    console.log('Set these fields in your config.js file: ');
-    console.log('baseTokenUri: ', baseTokenUri);
-    console.log('contractUri: ', contractUri);
-
-    return {
-      baseTokenUri,
-      contractUri,
-    };
-  });
+  return {
+    baseTokenUri,
+    contractUri,
+  };
 }
 
 nftStorageUpload();


### PR DESCRIPTION
This updates the NFT.storage uploader to upload sequentially and mitigates the risks of rate-limiting. It also provides a bit more visual feedback on the progress which might be useful to large projects.