### PR TITLE
Add NFT.storage clean utility

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "minter": "cosmwasm-cli --init scripts/minter.ts --code 'process.exit(0)'",
     "mint": "cosmwasm-cli --init scripts/mint.ts --code 'process.exit(0)'",
     "nft-storage-upload": "ts-node scripts/nft-storage-upload.ts",
+    "nft-storage-clean": "ts-node scripts/nft-storage-clean.ts",
     "batch-mint": "cosmwasm-cli --init scripts/mint-batch.ts --code 'process.exit(0)'",
     "whitelist": "cosmwasm-cli --init scripts/whitelist.ts --code 'process.exit(0)'",
     "load": "cosmwasm-cli --init scripts/load.ts",

--- a/scripts/nft-storage-clean.ts
+++ b/scripts/nft-storage-clean.ts
@@ -1,0 +1,54 @@
+import { NFTStorage } from 'nft.storage';
+// import { URL, URLSearchParams } from 'url';
+// import fetch from 'node-fetch';
+
+// Load config
+const config = require('../config');
+const https = require('https');
+
+// Configure NFT.storage
+const token = config.nftStorageApiKey;
+const client = new NFTStorage({ token });
+
+// Delete all files from NFT.storage
+export async function nftStorageClean() {
+  const listUrl = new URL(``, client.endpoint);
+  listUrl.search = new URLSearchParams([['limit', '1000']]).toString();
+
+  https
+    .get(
+      listUrl.toString(),
+      { headers: NFTStorage.auth(token) },
+      (res: any) => {
+        console.log(res);
+        let data: any[] = [];
+        const headerDate =
+          res.headers && res.headers.date
+            ? res.headers.date
+            : 'no response date';
+        console.log('Status Code:', res.statusCode);
+        console.log('Date in Response header:', headerDate);
+
+        res.on('data', (chunk: any) => {
+          data.push(chunk);
+        });
+
+        res.on('end', async () => {
+          console.log('Response ended: ');
+          const files = JSON.parse(Buffer.concat(data).toString());
+          const total = files.value.length;
+          let fileIndex = 1;
+          for (let f of files.value) {
+            console.log(`Deleting ${fileIndex}/${total} : ${f.cid}`);
+            await client.delete(f.cid);
+            fileIndex++;
+          }
+        });
+      }
+    )
+    .on('error', (err: any) => {
+      console.log('Error: ', err.message);
+    });
+}
+
+nftStorageClean();


### PR DESCRIPTION
Adds `yarn run nft-storage-clean` which will delete (up to 1000 at a time) files from you NFT.storage account. Useful in case things fail and you need to start over.