### PR TITLE
Fix mismatched metadata files

### DIFF
--- a/scripts/nft-storage-upload.ts
+++ b/scripts/nft-storage-upload.ts
@@ -4,6 +4,7 @@ import mime from 'mime';
 import { NFTStorage, Blob, File } from 'nft.storage';
 import os from 'os';
 import path from 'path';
+import { naturalCompare } from '../src/sort';
 import { checkFiles } from '../src/validation';
 
 // Load config
@@ -40,60 +41,53 @@ export async function nftStorageUpload() {
   const images = fs.readdirSync(imagesBasePath);
   const metadata = fs.readdirSync(metadataBasePath);
 
+  // Sort files (need to be in natural order)
+  images.sort(naturalCompare);
+  metadata.sort(naturalCompare);
+
   // Validation
   checkFiles(images, metadata);
 
-  // Upload each image to IPFS and store hash in array
-  const imagePromises = images.map(async (image) => {
-    const imagePath = `${imagesBasePath}/${image}`;
-    const readableFile = await fs.promises.readFile(imagePath);
-    const type = mime.getType(imagePath);
+  // Upload images folder
+  const imageFiles = await getFilesFromPath(imagesBasePath);
+  const imagesBaseUri = await client.storeDirectory(imageFiles as any);
 
-    // Upload to IPFS
-    return await client.storeBlob(
-      new File([readableFile], path.basename(imagePath), { type } as any)
+  // Create temp upload folder for metadata
+  const tmpFolder = fs.mkdtempSync(path.join(os.tmpdir(), 'galaxy'));
+
+  // Update metadata with IPFS hashes
+  metadata.map(async (file, index: number) => {
+    // Read JSON file
+    let metadata = JSON.parse(
+      fs.readFileSync(`${metadataBasePath}/${file}`, 'utf8')
     );
+
+    // Set image to upload image IPFS hash
+    metadata.image = `ipfs://${imagesBaseUri}/images/${images[index]}`;
+
+    // Write updated metadata to tmp folder
+    // We add 1, because token IDs start at 1
+    fs.writeFileSync(`${tmpFolder}/${index + 1}`, JSON.stringify(metadata));
   });
 
-  // Wait for all images to be uploaded
-  await Promise.all(imagePromises).then(async (images) => {
-    // Create temp upload folder for metadata
-    const tmpFolder = fs.mkdtempSync(path.join(os.tmpdir(), 'galaxy'));
+  // Upload tmpFolder
+  const files = await getFilesFromPath(tmpFolder);
+  const result = await client.storeDirectory(files as any);
 
-    // Update metadata with IPFS hashes
-    metadata.map(async (file, index: number) => {
-      // Read JSON file
-      let metadata = JSON.parse(
-        fs.readFileSync(`${metadataBasePath}/${file}`, 'utf8')
-      );
+  // Project will have been uploaded into a randomly name folder
+  const projectPath = tmpFolder.split('/').pop();
 
-      // Set image to upload image IPFS hash
-      metadata.image = `ipfs://${images[index]}`;
+  // Set base token uri
+  const baseTokenUri = `ipfs://${result}/${projectPath}`;
 
-      // Write updated metadata to tmp folder
-      // We add 1, because token IDs start at 1
-      fs.writeFileSync(`${tmpFolder}/${index + 1}`, JSON.stringify(metadata));
-    });
+  console.log('Set these fields in your config.js file: ');
+  console.log('baseTokenUri: ', baseTokenUri);
+  console.log('contractUri: ', contractUri);
 
-    // Upload tmpFolder
-    const files = await getFilesFromPath(tmpFolder);
-    const result = await client.storeDirectory(files as any);
-
-    // Project will have been uploaded into a randomly name folder
-    const projectPath = tmpFolder.split('/').pop();
-
-    // Set base token uri
-    const baseTokenUri = `ipfs://${result}/${projectPath}`;
-
-    console.log('Set these fields in your config.js file: ');
-    console.log('baseTokenUri: ', baseTokenUri);
-    console.log('contractUri: ', contractUri);
-
-    return {
-      baseTokenUri,
-      contractUri,
-    };
-  });
+  return {
+    baseTokenUri,
+    contractUri,
+  };
 }
 
 nftStorageUpload();

--- a/src/sort.ts
+++ b/src/sort.ts
@@ -1,0 +1,21 @@
+// @ts-nocheck
+// https://stackoverflow.com/questions/15478954/sort-array-elements-string-with-numbers-natural-sort/15479354#15479354
+export function naturalCompare(a: string, b: string) {
+  var ax = [];
+  var bx = [];
+  a.replace(/(\d+)|(\D+)/g, function (_, $1, $2) {
+    ax.push([$1 || Infinity, $2 || '']);
+  });
+  b.replace(/(\d+)|(\D+)/g, function (_, $1, $2) {
+    bx.push([$1 || Infinity, $2 || '']);
+  });
+
+  while (ax.length && bx.length) {
+    var an = ax.shift();
+    var bn = bx.shift();
+    var nn = an[0] - bn[0] || an[1].localeCompare(bn[1]);
+    if (nn) return nn;
+  }
+
+  return ax.length - bx.length;
+}


### PR DESCRIPTION
Node.js loads files in alphabetical order, we want [natural sort](https://en.wikipedia.org/wiki/Natural_sort_order) (1, 2, 3, etc.).

Didn't realize this because I was testing with small collections. :sweat_smile:

Also, updated the scripts to upload the whole image folder rather than all the files individually.
