### PR TITLE
query shows all minters addrs

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "pinata-upload": "ts-node scripts/pinata-upload.ts",
     "pinata-clean": "ts-node scripts/pinata-clean.ts",
     "query": "ts-node scripts/query.ts",
+    "query-minters": "ts-node scripts/query-minters.ts",
     "ts": "tsc --noEmit --incremental",
     "whitelist": "ts-node scripts/whitelist.ts",
     "whitelist-file": "ts-node scripts/whitelist-file.ts",

--- a/scripts/query-minters.ts
+++ b/scripts/query-minters.ts
@@ -1,5 +1,4 @@
 import { CosmWasmClient } from 'cosmwasm';
-import { toStars } from '../src/utils';
 
 const config = require('../config');
 

--- a/scripts/query-minters.ts
+++ b/scripts/query-minters.ts
@@ -1,0 +1,13 @@
+import { CosmWasmClient } from 'cosmwasm';
+import { toStars } from '../src/utils';
+
+const config = require('../config');
+
+async function queryMinters() {
+  const client = await CosmWasmClient.connect(config.rpcEndpoint);
+  const minterCodeId = config.minterCodeId;
+  const contracts = await client.getContracts(minterCodeId);
+
+  console.log('minter contract addrs: ', contracts.join(','));
+}
+queryMinters();


### PR DESCRIPTION
expand tools so contract queries are more accessible to creators

fix #184 