### PR TITLE
Adding burn functionality to the standard toolset

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "airdrop-file": "ts-node scripts/airdrop-file.ts",
     "minter": "ts-node scripts/minter.ts",
     "mint": "ts-node scripts/mint.ts",
+    "burn":"ts-node scripts/burn.ts",
     "nft-storage-upload": "ts-node scripts/nft-storage-upload.ts",
     "nft-storage-clean": "ts-node scripts/nft-storage-clean.ts",
     "pack-images": "ipfs-car --pack images --output images.car",

--- a/scripts/burn.ts
+++ b/scripts/burn.ts
@@ -1,0 +1,38 @@
+import { MsgExecuteContractEncodeObject, coins, toUtf8 } from 'cosmwasm';
+import { MsgExecuteContract } from 'cosmjs-types/cosmwasm/wasm/v1/tx';
+import { getClient } from '../src/client';
+import { toStars } from '../src/utils';
+
+const config = require('../config');
+
+async function burn_token(token: string) {
+  const client = await getClient();
+
+  console.log('SG721: ', config.sg721);
+  console.log('Burning Token: ', token);
+
+  const msg = { burn: { token_id: token } };
+  console.log(JSON.stringify(msg, null, 2));
+
+  const result = await client.execute(
+    config.account,
+    config.sg721,
+    msg,
+    'auto',
+    'burn'
+  );
+  const wasmEvent = result.logs[0].events.find((e) => e.type === 'wasm');
+  console.info(
+    'The `wasm` event emitted by the contract execution:',
+    wasmEvent
+  );
+}
+
+const args = process.argv.slice(2);
+if (args.length == 0) {
+  console.log('No arguments provided, need token to burn');
+} else if (args.length == 1) {
+  burn_token(args[0]);
+}  else {
+  console.log('Invalid arguments');
+}

--- a/scripts/burn.ts
+++ b/scripts/burn.ts
@@ -2,6 +2,7 @@ import { MsgExecuteContractEncodeObject, coins, toUtf8 } from 'cosmwasm';
 import { MsgExecuteContract } from 'cosmjs-types/cosmwasm/wasm/v1/tx';
 import { getClient } from '../src/client';
 import { toStars } from '../src/utils';
+import inquirer from 'inquirer';
 
 const config = require('../config');
 
@@ -10,9 +11,19 @@ async function burn_token(token: string) {
 
   console.log('SG721: ', config.sg721);
   console.log('Burning Token: ', token);
-
   const msg = { burn: { token_id: token } };
   console.log(JSON.stringify(msg, null, 2));
+  console.log(
+    'Please confirm that you would like to burn this token? This cannot be undone. Also note that this script can only burn tokens from your own wallet.'
+  );
+  const answer = await inquirer.prompt([
+    {
+      message: 'Ready to burn this token?',
+      name: 'confirmation',
+      type: 'confirm',
+    },
+  ]);
+  if (!answer.confirmation) return;
 
   const result = await client.execute(
     config.account,


### PR DESCRIPTION
Hi all - I love your tooling, and I added a small extra script to use the Burn functionality available in the sg721 contract. I needed this for an upcoming project we're working on, but I figured I'd also ship it your way in case you think others would find it useful. This just burns a single token right now but of course it could be pretty easily extended to burn multiple if that was needed.