### PR TITLE
Validate metadata

### DIFF
--- a/scripts/nft-storage-upload.ts
+++ b/scripts/nft-storage-upload.ts
@@ -4,7 +4,7 @@ import { NFTStorage } from 'nft.storage';
 import os from 'os';
 import path from 'path';
 import { naturalCompare } from '../src/sort';
-import { checkFiles } from '../src/validation';
+import { checkFiles, validateMetadata } from '../src/validation';
 
 // Load config
 const config = require('../config');
@@ -33,6 +33,9 @@ export async function nftStorageUpload() {
 
   // Validation
   checkFiles(images, metadata);
+
+  // Validate metadata attribute values
+  validateMetadata(metadataBasePath, metadata);
 
   // Upload images folder
   const imageFiles = await getFilesFromPath(imagesBasePath);

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -56,10 +56,14 @@ export const validateMetadata = (
       fs.readFileSync(`${metadataBasePath}/${file}`, 'utf8')
     );
 
-    // iterate attributes, error unless 'value:' is a string
+    // iterate attributes,
+    // confirm value and trait_type exists and trait type is string
+    // else error
     metadata.attributes.map((item: any) => {
-      if (typeof item.value !== 'string') {
-        throw Error('Attribute values must be a string');
+      if ('trait_type' in item) {
+        if (typeof item.trait_type !== 'string' || !('value' in item)) {
+          throw Error('Attribute trait_type must be a string and have a value');
+        }
       }
     });
   });

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -1,3 +1,5 @@
+import fs from 'fs';
+
 export const checkFiles = (images: string[], metadata: string[]) => {
   // Check images length is equal to metadata length
   if (images.length !== metadata.length) {
@@ -42,4 +44,23 @@ export const checkFiles = (images: string[], metadata: string[]) => {
     }
     lastValue = image;
   }
+};
+
+export const validateMetadata = (
+  metadataBasePath: string,
+  metadata: string[]
+) => {
+  metadata.map(async (file, index: number) => {
+    // Read JSON file
+    let metadata = JSON.parse(
+      fs.readFileSync(`${metadataBasePath}/${file}`, 'utf8')
+    );
+
+    // iterate attributes, error unless 'value:' is a string
+    metadata.attributes.map((item: any) => {
+      if (typeof item.value !== 'string') {
+        throw Error('Attribute values must be a string');
+      }
+    });
+  });
 };


### PR DESCRIPTION
I was asked to redo my metadata because there was a an attribute value which was not a string. It would have been handy to catch that with a validation on initial upload. This PR adds a validation for metadata attributes values.

The metdata I had:
```
{
    "attributes": [
        {
            "trait_type": "background_color",
            "value": "whitesmoke"
        },
        {
            "trait_type": "mouth",
            "value": "side_down_right"
        },
        {
            "display_type": "number",
            "trait_type": "generation",
            "value": 1
        }
```

Apparently the 1 was causing an issue confirming the metadata on testnet, I had to redo it to:
```
{
    "attributes": [
...
...
        {
            "display_type": "number",
            "trait_type": "generation",
            "value": "1"
        }
```

