### PR TITLE
Added --unique-only argument for batch airdrop script.

### DIFF
--- a/scripts/airdrop-file.ts
+++ b/scripts/airdrop-file.ts
@@ -130,9 +130,9 @@ async function addFile(uniqueOnly: boolean) {
 
 const args = process.argv.slice(2);
 if (args.length == 0) {
-  addFile(false)
-} else if (args.length == 1 && args[0] == '--unique-only') {
   addFile(true)
+} else if (args.length == 1 && args[0] == '--keep-duplicates') {
+  addFile(false)
 } else {
-  console.log('Invalid argument. Expected --unique-only');
+  console.log('Invalid arguments.');
 }

--- a/scripts/airdrop-file.ts
+++ b/scripts/airdrop-file.ts
@@ -24,7 +24,7 @@ const config = require('../config');
 const AIRDROP_FEE = coin(0, 'ustars');
 const MSG_AIRDROP_LIMIT = 50;
 
-async function addFile() {
+async function addFile(uniqueOnly: boolean) {
   interface Airdrop {
     address: string;
   }
@@ -58,23 +58,31 @@ async function addFile() {
       addrs.forEach((addr) => {
         validatedAddrs.push(toStars(addr));
       });
-      let uniqueValidatedAddrs = [...new Set(validatedAddrs)].sort();
-      if (uniqueValidatedAddrs.length > MSG_AIRDROP_LIMIT) {
+
+      let finalAddrs: Array<string>
+
+      if(uniqueOnly){
+        finalAddrs = [...new Set(validatedAddrs)].sort();
+      } else {
+        finalAddrs = validatedAddrs
+      }
+
+      if (finalAddrs.length > MSG_AIRDROP_LIMIT) {
         throw new Error(
           'Too many addrs added in a transaction. Max ' +
-            MSG_AIRDROP_LIMIT +
-            ' at a time.'
+          MSG_AIRDROP_LIMIT +
+          ' at a time.'
         );
       }
       console.log(
         'Airdrop addresses validated and deduped. count: ' +
-          uniqueValidatedAddrs.length
+        finalAddrs.length
       );
 
-      for (const idx in uniqueValidatedAddrs) {
-        console.log('airdropping to address: ', uniqueValidatedAddrs[idx]);
+      for (const idx in finalAddrs) {
+        console.log('airdropping to address: ', finalAddrs[idx]);
         const msg: ExecuteMsg = {
-          mint_to: { recipient: uniqueValidatedAddrs[idx] },
+          mint_to: { recipient: finalAddrs[idx] },
         };
         const executeContractMsg: MsgExecuteContractEncodeObject = {
           typeUrl: '/cosmwasm.wasm.v1.MsgExecuteContract',
@@ -120,4 +128,11 @@ async function addFile() {
   );
 }
 
-addFile();
+const args = process.argv.slice(2);
+if (args.length == 0) {
+  addFile(false)
+} else if (args.length == 1 && args[0] == '--unique-only') {
+  addFile(true)
+} else {
+  console.log('Invalid argument. Expected --unique-only');
+}


### PR DESCRIPTION
By default, the script will now airdrop a single token for each address in the CSV. Passing the --unique-only argument will airdrop to unique addresses.