### PR TITLE
fix(whitelist): Handle empty lines & records; trim whitespace

### DIFF
--- a/src/whitelist/whitelist-file.ts
+++ b/src/whitelist/whitelist-file.ts
@@ -37,8 +37,11 @@ async function addFile() {
     {
       delimiter: ',',
       columns: headers,
+      skip_empty_lines: true,
+      skip_records_with_empty_values: true,
+      trim: true,
     },
-    async (error, fileContents: Whitelist[]) => {
+    async (error: any, fileContents: Whitelist[]) => {
       if (error) {
         throw error;
       }


### PR DESCRIPTION
scope of changes: added support for

- skipping blank lines
- skipping empty records
- trimming spaces around records

comments:

changes were made on the basis of [config options ](https://csv.js.org/parse/options/) documented in the csv-parse package. I didn't see any tests so `yolo`